### PR TITLE
Logging modifiziert/Test

### DIFF
--- a/VTM Framework Tests/Logging/LoggingTest.cs
+++ b/VTM Framework Tests/Logging/LoggingTest.cs
@@ -1,0 +1,43 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using VtmFramework.Logging;
+
+namespace VtmFrameworkTests.Logging {
+    [TestClass]
+    public class LoggingTest {
+
+        private IVTMLogger _log;
+        private string _path;
+
+        [TestInitialize]
+        public void TestInitialize() {
+            _path = ".\\TestLog.log";
+            VTMLogger.SetLoggingLevel(TraceLevel.Verbose);
+            _log = VTMLoggerFactory.getInstance(_path);
+            //_log = VTMLoggerFactory.getInstance();
+        }
+
+        [TestMethod]
+        public void TestLogging() {
+            //_log.Info("Das ist eine Info");
+            //_log.Warning("Das ist eine Warnung!");
+            //_log.Error("TestError 001");
+            //_log.Error(new NullReferenceException("NullException 002"));
+            Assert.AreEqual(File.Exists(_path), true,"LogFile korrekt angelegt");
+        }
+
+
+        [TestCleanup]
+        public void Cleanup() {
+            //Löschen des TestLog-Files
+            _log.Dispose();
+            System.IO.File.Delete(_path);
+        }
+    }
+}

--- a/VTM Framework Tests/VTM Framework Tests.csproj
+++ b/VTM Framework Tests/VTM Framework Tests.csproj
@@ -54,6 +54,7 @@
   <ItemGroup>
     <Compile Include="Command\AwaitableDelegateCommandTest.cs" />
     <Compile Include="Library\StrLibTest.cs" />
+    <Compile Include="Logging\LoggingTest.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Command\DelegateCommandTest.cs" />
     <Compile Include="Scheduler\SchedulerTest.cs" />

--- a/VTMFramework/Logging/IVTMLogger.cs
+++ b/VTMFramework/Logging/IVTMLogger.cs
@@ -1,11 +1,12 @@
 ﻿using System;
 namespace VtmFramework.Logging {
 
-    public interface IVtmLogger {
+    public interface IVTMLogger {
         void Error(Exception ex);
         void Error(string errorMessage);
         void Info(string infoMessage);
         void Warning(string warningMessage);
+        void Dispose();
     }
 
 }

--- a/VTMFramework/Logging/VTMLoggerFactory.cs
+++ b/VTMFramework/Logging/VTMLoggerFactory.cs
@@ -9,12 +9,12 @@ using System.Threading.Tasks;
 namespace VtmFramework.Logging {
     public static class VTMLoggerFactory {
 
-        public static IVtmLogger getInstance (string logPath) {
+        public static IVTMLogger getInstance (string logPath) {
             VTMLogger.LogPath = logPath;
             return getInstance();
         }
 
-        public static IVtmLogger getInstance () {
+        public static IVTMLogger getInstance () {
             return VTMLogger.Instance;
         }
 

--- a/VTMFramework/ViewModel/ErrorViewModel.cs
+++ b/VTMFramework/ViewModel/ErrorViewModel.cs
@@ -26,7 +26,7 @@ namespace VtmFramework.ViewModel {
             Visible = Visibility.Visible;
         }
 
-        public ErrorViewModel(Exception ex, IVtmLogger logger)
+        public ErrorViewModel(Exception ex, IVTMLogger logger)
             : this() {
             if (logger != null) logger.Error(ex);
         }

--- a/VTMFramework/ViewModel/ErrorViewModelFactory.cs
+++ b/VTMFramework/ViewModel/ErrorViewModelFactory.cs
@@ -10,7 +10,7 @@ namespace VtmFramework.ViewModel {
 
     public static class ErrorViewModelFactory {
 
-        private static IVtmLogger _logger = VTMLoggerFactory.getInstance();
+        private static IVTMLogger _logger = VTMLoggerFactory.getInstance();
 
         public static ErrorViewModel GetInstance(string title, string message, EErrorButtons buttonSet, IObserver<EErrorResult> observer) {
             ErrorViewModel evm = new ErrorViewModel();


### PR DESCRIPTION
Logger verfügt nun über VTMLogger.Dispose() zur Freigabe des DateiHandels.

Logging-Test erstellt (Testausgaben konnnten aufgrund der Funktionalität von Trace.Write() in Unit Tests nicht getestet werden)
File und Path-Verarbeitung getestet.
Freigabe des Logfiles abgetestet.
